### PR TITLE
Align OAuth pool with Claude CLI: Retry-After, accountId, scope validation, User-Agent, login_hint

### DIFF
--- a/inc/rest-api.php
+++ b/inc/rest-api.php
@@ -43,6 +43,27 @@ function register_routes(): void {
 			'methods'             => 'GET',
 			'callback'            => __NAMESPACE__ . '\\rest_start_oauth',
 			'permission_callback' => __NAMESPACE__ . '\\can_manage',
+			'args'                => [
+				'login_hint'   => [
+					'required'          => false,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_email',
+					'description'       => 'Pre-populate the email field on the Anthropic login page.',
+				],
+				'login_method' => [
+					'required'          => false,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+					'enum'              => [ 'sso', 'magic_link', 'google' ],
+					'description'       => 'Request a specific login method.',
+				],
+				'org_uuid'     => [
+					'required'          => false,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+					'description'       => 'Pre-select an org UUID for team/enterprise logins.',
+				],
+			],
 		]
 	);
 
@@ -145,11 +166,21 @@ function rest_list_accounts(): \WP_REST_Response {
 /**
  * Starts the OAuth PKCE flow and returns the authorize URL.
  *
+ * Accepts optional query params:
+ *   - login_hint:   pre-populate the email on the Anthropic login page.
+ *   - login_method: request a specific login method ('sso', 'magic_link', 'google').
+ *   - org_uuid:     pre-select an org for team/enterprise logins.
+ *
+ * @param \WP_REST_Request $request The request object.
  * @return \WP_REST_Response
  */
-function rest_start_oauth(): \WP_REST_Response {
+function rest_start_oauth( \WP_REST_Request $request ): \WP_REST_Response {
 	$pool = PoolManager::getInstance();
-	$data = $pool->startOAuthFlow();
+	$data = $pool->startOAuthFlow(
+		$request->get_param( 'login_hint' ) ?: null,
+		$request->get_param( 'login_method' ) ?: null,
+		$request->get_param( 'org_uuid' ) ?: null
+	);
 
 	// Only return the authorize URL and state (never the verifier).
 	return rest_ensure_response( [
@@ -185,6 +216,22 @@ function rest_exchange_code( \WP_REST_Request $request ) {
 			'exchange_failed',
 			__( 'Failed to exchange authorization code. The code may be expired or the state is invalid.', 'ai-provider-for-anthropic-max' ),
 			[ 'status' => 400 ]
+		);
+	}
+
+	// Scope validation failure: the token was issued but is missing user:inference.
+	// The account was NOT added to the pool. Return a clear error so the UI can
+	// prompt the user to re-authorize with the correct scopes.
+	if ( ! empty( $result['scope_error'] ) ) {
+		$granted = implode( ' ', (array) ( $result['granted_scopes'] ?? [] ) );
+		return new \WP_Error(
+			'insufficient_scope',
+			sprintf(
+				/* translators: %s: space-separated list of granted scopes */
+				__( 'Authorization succeeded but the token is missing the required "user:inference" scope. Granted scopes: %s. Please re-authorize and ensure you are using a Claude Max subscription account.', 'ai-provider-for-anthropic-max' ),
+				$granted ?: __( '(none)', 'ai-provider-for-anthropic-max' )
+			),
+			[ 'status' => 403 ]
 		);
 	}
 

--- a/src/Authentication/AnthropicOAuthRequestAuthentication.php
+++ b/src/Authentication/AnthropicOAuthRequestAuthentication.php
@@ -36,6 +36,16 @@ class AnthropicOAuthRequestAuthentication implements RequestAuthenticationInterf
     private PoolManager $pool;
 
     /**
+     * The email of the account whose token was last used.
+     *
+     * Populated by authenticateRequest() so callers can identify which
+     * account to mark as rate-limited on a 429/529 response.
+     *
+     * @var string|null
+     */
+    private ?string $activeEmail = null;
+
+    /**
      * Constructor.
      *
      * @param PoolManager $pool The pool manager to retrieve tokens from.
@@ -49,7 +59,8 @@ class AnthropicOAuthRequestAuthentication implements RequestAuthenticationInterf
      * Authenticates the request with an OAuth Bearer token.
      *
      * Retrieves the best available token from the pool, auto-refreshing
-     * expired tokens as needed.
+     * expired tokens as needed. Caches the active account email so that
+     * callers can mark it as rate-limited on a 429/529 response.
      *
      * @since 1.0.0
      *
@@ -60,19 +71,35 @@ class AnthropicOAuthRequestAuthentication implements RequestAuthenticationInterf
      */
     public function authenticateRequest(Request $request): Request
     {
-        $token = $this->pool->getActiveToken();
+        $result = $this->pool->getActiveTokenWithEmail();
 
-        if (empty($token)) {
+        if ($result === null || empty($result['token'])) {
             throw new \RuntimeException(
                 'No active OAuth token available in the Anthropic Max account pool. ' .
                 'Add an account via Settings > Connectors.'
             );
         }
 
+        $this->activeEmail = $result['email'];
+
         $request = $request->withHeader('anthropic-version', self::ANTHROPIC_API_VERSION);
         $request = $request->withHeader('anthropic-beta', self::ANTHROPIC_OAUTH_BETA);
 
-        return $request->withHeader('Authorization', 'Bearer ' . $token);
+        return $request->withHeader('Authorization', 'Bearer ' . $result['token']);
+    }
+
+    /**
+     * Returns the email of the account whose token was last used.
+     *
+     * Returns null if authenticateRequest() has not been called yet.
+     *
+     * @since 1.0.0
+     *
+     * @return string|null
+     */
+    public function getActiveEmail(): ?string
+    {
+        return $this->activeEmail;
     }
 
     /**

--- a/src/Authentication/AnthropicOAuthRequestAuthentication.php
+++ b/src/Authentication/AnthropicOAuthRequestAuthentication.php
@@ -71,6 +71,7 @@ class AnthropicOAuthRequestAuthentication implements RequestAuthenticationInterf
      */
     public function authenticateRequest(Request $request): Request
     {
+        $this->activeEmail = null;
         $result = $this->pool->getActiveTokenWithEmail();
 
         if ($result === null || empty($result['token'])) {

--- a/src/Models/AnthropicMaxTextGenerationModel.php
+++ b/src/Models/AnthropicMaxTextGenerationModel.php
@@ -36,6 +36,7 @@ use WordPress\AiClient\Tools\DTO\FunctionCall;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 use WordPress\AiClient\Tools\DTO\WebSearch;
 use AnthropicMaxAiProvider\Authentication\AnthropicOAuthRequestAuthentication;
+use AnthropicMaxAiProvider\OAuthPool\PoolManager;
 use AnthropicMaxAiProvider\Provider\AnthropicMaxProvider;
 
 /**
@@ -76,12 +77,16 @@ class AnthropicMaxTextGenerationModel extends AbstractApiBasedModel implements T
         }
 
         // Fallback: build OAuth auth from the pool manager.
-        $pool = \AnthropicMaxAiProvider\OAuthPool\PoolManager::getInstance();
+        $pool = PoolManager::getInstance();
         return new AnthropicOAuthRequestAuthentication($pool);
     }
 
     /**
      * Generates a text result using the Anthropic Messages API.
+     *
+     * On 429 (rate limit) or 529 (API overloaded) responses, the active account
+     * is marked as rate-limited in the pool using the Retry-After header value
+     * when present, falling back to the pool's DEFAULT_COOLDOWN_MS.
      *
      * @since 1.0.0
      *
@@ -108,12 +113,85 @@ class AnthropicMaxTextGenerationModel extends AbstractApiBasedModel implements T
             $this->getRequestOptions()
         );
 
-        $request  = $this->getRequestAuthentication()->authenticateRequest($request);
+        $auth     = $this->getRequestAuthentication();
+        $request  = $auth->authenticateRequest($request);
         $response = $httpTransporter->send($request);
+
+        // On rate-limit or overload responses, mark the active account with the
+        // server-specified cooldown before letting the SDK throw its exception.
+        // 429 = rate limited; 529 = Anthropic API overloaded.
+        $status_code = $response->getStatusCode();
+        if ($status_code === 429 || $status_code === 529) {
+            $this->handleRateLimitResponse($auth, $response);
+        }
 
         ResponseUtil::throwIfNotSuccessful($response);
 
         return $this->parseResponseToGenerativeAiResult($response);
+    }
+
+    /**
+     * Marks the active pool account as rate-limited based on the API response.
+     *
+     * Extracts the Retry-After header (seconds or HTTP-date) and passes it to
+     * the pool manager. Falls back to DEFAULT_COOLDOWN_MS when absent.
+     *
+     * @since 1.0.0
+     *
+     * @param RequestAuthenticationInterface $auth     The request authentication instance.
+     * @param Response                       $response The rate-limit response.
+     * @return void
+     */
+    protected function handleRateLimitResponse(
+        RequestAuthenticationInterface $auth,
+        Response $response
+    ): void {
+        // Only act when using our OAuth auth — we need the pool manager.
+        if (!($auth instanceof AnthropicOAuthRequestAuthentication)) {
+            return;
+        }
+
+        $pool  = PoolManager::getInstance();
+        $email = $auth->getActiveEmail();
+
+        if ($email === null) {
+            return;
+        }
+
+        // Parse Retry-After header: integer seconds or HTTP-date.
+        $retry_after_secs = $this->parseRetryAfterHeader($response);
+        $pool->markRateLimited($email, null, $retry_after_secs);
+    }
+
+    /**
+     * Parses the Retry-After header from an SDK Response.
+     *
+     * Supports integer (seconds) and HTTP-date formats per RFC 7231.
+     *
+     * @since 1.0.0
+     *
+     * @param Response $response The HTTP response.
+     * @return int|null Retry-After in seconds, or null if absent/unparseable.
+     */
+    protected function parseRetryAfterHeader(Response $response): ?int
+    {
+        $header = $response->getHeaderAsString('retry-after');
+        if ($header === null || $header === '') {
+            return null;
+        }
+
+        // Integer seconds: "Retry-After: 60"
+        if (ctype_digit($header)) {
+            return (int) $header;
+        }
+
+        // HTTP-date: "Retry-After: Wed, 21 Oct 2025 07:28:00 GMT"
+        $timestamp = strtotime($header);
+        if ($timestamp !== false && $timestamp > time()) {
+            return $timestamp - time();
+        }
+
+        return null;
     }
 
     /**

--- a/src/OAuthPool/PoolManager.php
+++ b/src/OAuthPool/PoolManager.php
@@ -439,8 +439,9 @@ class PoolManager
         $pool   = $this->loadPool();
         $now_ms = $this->nowMs();
 
-        if ($retry_after_secs !== null && $retry_after_secs > 0) {
+        if ($retry_after_secs !== null) {
             // Retry-After takes precedence — use the server-specified window.
+            // A value of 0 is authoritative (server says retry immediately).
             $cooldown_ms = $retry_after_secs * 1000;
         } elseif ($cooldown_ms === null) {
             $cooldown_ms = self::DEFAULT_COOLDOWN_MS;
@@ -601,11 +602,14 @@ class PoolManager
      * Optional parameters align with Claude CLI's authorize URL support:
      *   - login_hint:   pre-populate the email field on the login page (standard OIDC).
      *   - login_method: request a specific login method ('sso', 'magic_link', 'google').
-     *   - org_uuid:     pre-select an org for team/enterprise logins.
+     *
+     * Note: org_uuid is accepted for API compatibility but is not appended to the
+     * authorize URL — the claude.ai authorize endpoint does not support orgUUID as
+     * a query parameter.
      *
      * @param string|null $login_hint   Optional email to pre-populate on the login page.
      * @param string|null $login_method Optional login method ('sso', 'magic_link', 'google').
-     * @param string|null $org_uuid     Optional org UUID for team/enterprise logins.
+     * @param string|null $org_uuid     Accepted for compatibility; not used in the authorize URL.
      * @return array{verifier: string, challenge: string, state: string, authorize_url: string}
      */
     public function startOAuthFlow(
@@ -640,9 +644,6 @@ class PoolManager
         }
         if ($login_method !== null && $login_method !== '') {
             $params['login_method'] = $login_method;
-        }
-        if ($org_uuid !== null && $org_uuid !== '') {
-            $params['orgUUID'] = $org_uuid;
         }
 
         $authorize_url = self::AUTHORIZE_URL . '?' . http_build_query($params);

--- a/src/OAuthPool/PoolManager.php
+++ b/src/OAuthPool/PoolManager.php
@@ -34,6 +34,19 @@ class PoolManager
 
     /**
      * Anthropic OAuth constants (same as Claude CLI).
+     *
+     * Alignment notes (vs Claude CLI codebase):
+     *   CLIENT_ID       — identical to Claude CLI (public, same for all clients).
+     *   TOKEN_ENDPOINT  — identical to Claude CLI prod config.
+     *   AUTHORIZE_URL   — we hit claude.ai directly; Claude CLI now routes through
+     *                     https://claude.com/cai/oauth/authorize for attribution,
+     *                     which 307-redirects to claude.ai. Ours is the final dest.
+     *                     FALLBACK: if authorize breaks, try https://claude.com/cai/oauth/authorize.
+     *   REDIRECT_URI    — console.anthropic.com is the legacy Console domain.
+     *                     platform.claude.com is the current primary domain. Both
+     *                     redirect URIs are currently registered by Anthropic.
+     *                     FALLBACK: 'https://platform.claude.com/oauth/code/callback'
+     *   SCOPES          — identical to Claude CLI's ALL_OAUTH_SCOPES union.
      */
     public const CLIENT_ID      = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
     public const TOKEN_ENDPOINT  = 'https://platform.claude.com/v1/oauth/token';
@@ -42,9 +55,24 @@ class PoolManager
     public const SCOPES          = 'org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload';
 
     /**
+     * User-Agent sent on token exchange and refresh requests.
+     *
+     * Aligned with Claude CLI format: "claude-cli/{version} (external, cli)".
+     * The "(wordpress-plugin)" suffix identifies this client to Anthropic.
+     * FALLBACK: if UA filtering causes issues, try 'claude-cli/2.1.80'.
+     */
+    public const USER_AGENT = 'claude-cli/2.1.80 (wordpress-plugin)';
+
+    /**
      * Default cooldown duration for rate-limited accounts (5 minutes).
      */
     public const DEFAULT_COOLDOWN_MS = 300000;
+
+    /**
+     * Required scope that must be present in the granted scope list.
+     * A token missing this scope will fail at inference time.
+     */
+    public const REQUIRED_SCOPE = 'user:inference';
 
     /**
      * Singleton instance.
@@ -116,8 +144,96 @@ class PoolManager
                 'expiresIn'     => max(0, intdiv($expires_in_ms, 1000)),
                 'hasRefresh'    => !empty($account['refresh']),
                 'cooldownUntil' => $account['cooldownUntil'] ?? null,
+                'accountId'     => $account['accountId'] ?? null,
             ];
         }, $accounts);
+    }
+
+    /**
+     * Returns the best available access token and its account email.
+     *
+     * Same selection logic as getActiveToken(). Returns an associative array
+     * with 'token' and 'email' keys, or null if no account is available.
+     * Used by AnthropicOAuthRequestAuthentication to track which account
+     * is in use so it can be marked rate-limited on 429/529 responses.
+     *
+     * @return array{token: string, email: string}|null
+     */
+    public function getActiveTokenWithEmail(): ?array
+    {
+        $pool   = $this->loadPool();
+        $now_ms = $this->nowMs();
+
+        // Clear expired cooldowns.
+        $changed = false;
+        foreach ($pool['accounts'] as &$account) {
+            if (
+                ($account['status'] ?? '') === 'rate-limited' &&
+                isset($account['cooldownUntil']) &&
+                $account['cooldownUntil'] > 0 &&
+                $account['cooldownUntil'] <= $now_ms
+            ) {
+                $account['status']        = 'idle';
+                $account['cooldownUntil'] = null;
+                $changed                  = true;
+            }
+        }
+        unset($account);
+
+        if ($changed) {
+            $this->savePool($pool);
+        }
+
+        $best       = null;
+        $best_index = -1;
+
+        foreach ($pool['accounts'] as $index => $account) {
+            $status = $account['status'] ?? 'idle';
+            if ($status === 'rate-limited') {
+                continue;
+            }
+            if (empty($account['access'])) {
+                continue;
+            }
+            if ($best === null || ($account['lastUsed'] ?? '') < ($best['lastUsed'] ?? '')) {
+                $best       = $account;
+                $best_index = $index;
+            }
+        }
+
+        if ($best === null) {
+            return null;
+        }
+
+        $expires = $best['expires'] ?? 0;
+        if ($expires > 0 && $expires <= $now_ms && !empty($best['refresh'])) {
+            $refresher = new TokenRefresher();
+            $refreshed = $refresher->refresh($best['refresh']);
+
+            if ($refreshed !== null) {
+                $pool['accounts'][$best_index]['access']   = $refreshed['access_token'];
+                $pool['accounts'][$best_index]['expires']  = $now_ms + ($refreshed['expires_in'] * 1000);
+                $pool['accounts'][$best_index]['status']   = 'active';
+                $pool['accounts'][$best_index]['lastUsed'] = gmdate('Y-m-d\TH:i:s\Z');
+
+                if (!empty($refreshed['refresh_token'])) {
+                    $pool['accounts'][$best_index]['refresh'] = $refreshed['refresh_token'];
+                }
+
+                $this->savePool($pool);
+                return ['token' => $refreshed['access_token'], 'email' => $best['email'] ?? ''];
+            }
+
+            $pool['accounts'][$best_index]['status'] = 'refresh-failed';
+            $this->savePool($pool);
+            return null;
+        }
+
+        $pool['accounts'][$best_index]['status']   = 'active';
+        $pool['accounts'][$best_index]['lastUsed'] = gmdate('Y-m-d\TH:i:s\Z');
+        $this->savePool($pool);
+
+        return ['token' => $best['access'], 'email' => $best['email'] ?? ''];
     }
 
     /**
@@ -220,17 +336,19 @@ class PoolManager
     /**
      * Adds or updates an account in the pool.
      *
-     * @param string $email         The account email.
-     * @param string $access_token  The OAuth access token.
-     * @param string $refresh_token The OAuth refresh token.
-     * @param int    $expires_in    Token lifetime in seconds.
+     * @param string      $email         The account email.
+     * @param string      $access_token  The OAuth access token.
+     * @param string      $refresh_token The OAuth refresh token.
+     * @param int         $expires_in    Token lifetime in seconds.
+     * @param string|null $account_id    Optional account UUID from the token response.
      * @return int The total number of accounts in the pool.
      */
     public function addAccount(
         string $email,
         string $access_token,
         string $refresh_token,
-        int $expires_in
+        int $expires_in,
+        ?string $account_id = null
     ): int {
         $pool   = $this->loadPool();
         $now_ms = $this->nowMs();
@@ -248,14 +366,17 @@ class PoolManager
                 $account['lastUsed']      = $now;
                 $account['status']        = 'active';
                 $account['cooldownUntil'] = null;
-                $found                    = true;
+                if ($account_id !== null) {
+                    $account['accountId'] = $account_id;
+                }
+                $found = true;
                 break;
             }
         }
         unset($account);
 
         if (!$found) {
-            $pool['accounts'][] = [
+            $entry = [
                 'email'         => $email,
                 'access'        => $access_token,
                 'refresh'       => $refresh_token,
@@ -265,6 +386,10 @@ class PoolManager
                 'status'        => 'active',
                 'cooldownUntil' => null,
             ];
+            if ($account_id !== null) {
+                $entry['accountId'] = $account_id;
+            }
+            $pool['accounts'][] = $entry;
         }
 
         $this->savePool($pool);
@@ -301,16 +426,23 @@ class PoolManager
     /**
      * Marks an account as rate-limited with a cooldown period.
      *
-     * @param string   $email       The account email.
-     * @param int|null $cooldown_ms Cooldown in milliseconds (null for default).
+     * Respects a Retry-After value when provided (e.g. from a 429 response
+     * header). Falls back to DEFAULT_COOLDOWN_MS when not specified.
+     *
+     * @param string   $email            The account email.
+     * @param int|null $cooldown_ms      Cooldown in milliseconds (null for default).
+     * @param int|null $retry_after_secs Retry-After header value in seconds (overrides cooldown_ms).
      * @return bool Whether the account was found.
      */
-    public function markRateLimited(string $email, ?int $cooldown_ms = null): bool
+    public function markRateLimited(string $email, ?int $cooldown_ms = null, ?int $retry_after_secs = null): bool
     {
         $pool   = $this->loadPool();
         $now_ms = $this->nowMs();
 
-        if ($cooldown_ms === null) {
+        if ($retry_after_secs !== null && $retry_after_secs > 0) {
+            // Retry-After takes precedence — use the server-specified window.
+            $cooldown_ms = $retry_after_secs * 1000;
+        } elseif ($cooldown_ms === null) {
             $cooldown_ms = self::DEFAULT_COOLDOWN_MS;
         }
 
@@ -325,6 +457,22 @@ class PoolManager
         unset($account);
 
         return false;
+    }
+
+    /**
+     * Marks the currently active account as rate-limited based on an HTTP response.
+     *
+     * Parses the Retry-After header (seconds or HTTP-date) from the response
+     * and uses it as the cooldown duration. Falls back to DEFAULT_COOLDOWN_MS.
+     *
+     * @param string $email    The account email to mark.
+     * @param array  $response The wp_remote_* response array.
+     * @return bool Whether the account was found and marked.
+     */
+    public function markRateLimitedFromResponse(string $email, array $response): bool
+    {
+        $retry_after_secs = $this->parseRetryAfter($response);
+        return $this->markRateLimited($email, null, $retry_after_secs);
     }
 
     /**
@@ -395,6 +543,7 @@ class PoolManager
                 'status'       => $status,
                 'tokenExpired' => ($account['expires'] ?? 0) <= $now_ms,
                 'hasRefresh'   => !empty($account['refresh']),
+                'accountId'    => $account['accountId'] ?? null,
                 'validity'     => 'unknown',
             ];
 
@@ -423,6 +572,7 @@ class PoolManager
                     'Authorization'    => 'Bearer ' . $token,
                     'anthropic-version' => '2023-06-01',
                     'anthropic-beta'   => 'oauth-2025-04-20',
+                    'User-Agent'       => self::USER_AGENT,
                 ],
                 'timeout' => 10,
             ]
@@ -448,10 +598,21 @@ class PoolManager
     /**
      * Generates a PKCE verifier and challenge, stores the verifier in a transient.
      *
+     * Optional parameters align with Claude CLI's authorize URL support:
+     *   - login_hint:   pre-populate the email field on the login page (standard OIDC).
+     *   - login_method: request a specific login method ('sso', 'magic_link', 'google').
+     *   - org_uuid:     pre-select an org for team/enterprise logins.
+     *
+     * @param string|null $login_hint   Optional email to pre-populate on the login page.
+     * @param string|null $login_method Optional login method ('sso', 'magic_link', 'google').
+     * @param string|null $org_uuid     Optional org UUID for team/enterprise logins.
      * @return array{verifier: string, challenge: string, state: string, authorize_url: string}
      */
-    public function startOAuthFlow(): array
-    {
+    public function startOAuthFlow(
+        ?string $login_hint = null,
+        ?string $login_method = null,
+        ?string $org_uuid = null
+    ): array {
         // Generate PKCE code_verifier (43 chars, base64url no padding).
         $verifier  = $this->generateVerifier();
         $challenge = $this->generateChallenge($verifier);
@@ -460,16 +621,31 @@ class PoolManager
         // Store verifier + state in a transient (10 minute TTL).
         set_transient(self::PKCE_TRANSIENT_PREFIX . $state, $verifier, 600);
 
-        $authorize_url = self::AUTHORIZE_URL . '?' . http_build_query([
+        $params = [
             'client_id'             => self::CLIENT_ID,
-            'response_type'        => 'code',
-            'redirect_uri'         => self::REDIRECT_URI,
-            'scope'                => self::SCOPES,
-            'code_challenge'       => $challenge,
+            'response_type'         => 'code',
+            'redirect_uri'          => self::REDIRECT_URI,
+            'scope'                 => self::SCOPES,
+            'code_challenge'        => $challenge,
             'code_challenge_method' => 'S256',
-            'state'                => $state,
-            'code'                 => 'true',
-        ]);
+            'state'                 => $state,
+            // Alignment: &code=true matches Claude CLI — tells the login page to
+            // show the Claude Max upsell. Required for parity with the official client.
+            'code'                  => 'true',
+        ];
+
+        // Optional params supported by Claude CLI (not sent unless provided).
+        if ($login_hint !== null && $login_hint !== '') {
+            $params['login_hint'] = $login_hint;
+        }
+        if ($login_method !== null && $login_method !== '') {
+            $params['login_method'] = $login_method;
+        }
+        if ($org_uuid !== null && $org_uuid !== '') {
+            $params['orgUUID'] = $org_uuid;
+        }
+
+        $authorize_url = self::AUTHORIZE_URL . '?' . http_build_query($params);
 
         return [
             'verifier'      => $verifier,
@@ -482,10 +658,19 @@ class PoolManager
     /**
      * Exchanges an authorization code for tokens.
      *
+     * After a successful exchange, validates that the granted scope includes
+     * 'user:inference'. A token missing this scope will fail at inference time;
+     * catching it here gives a clearer error at add-account time.
+     *
+     * The token response may also contain an 'account' object with a UUID
+     * (account.uuid) which is stored as accountId for diagnostics.
+     *
      * @param string $code  The authorization code.
      * @param string $state The state nonce.
      * @param string $email The account email.
      * @return array{access_token: string, refresh_token: string, expires_in: int}|null
+     *         Returns null on failure. Returns WP_Error-compatible array on scope failure
+     *         via the 'scope_error' key set to true.
      */
     public function exchangeCode(string $code, string $state, string $email): ?array
     {
@@ -511,7 +696,7 @@ class PoolManager
             [
                 'headers' => [
                     'Content-Type' => 'application/json',
-                    'User-Agent'   => 'ai-provider-for-anthropic-max/1.0.0',
+                    'User-Agent'   => self::USER_AGENT,
                 ],
                 'body'    => $body,
                 'timeout' => 15,
@@ -532,14 +717,40 @@ class PoolManager
             return null;
         }
 
+        // Validate that the granted scope includes user:inference.
+        // The 'scope' field is a space-delimited string of granted scopes.
+        // Diagnostic: d.get('scope', '').split() should include 'user:inference'.
+        if (!empty($data['scope'])) {
+            $granted_scopes = explode(' ', (string) $data['scope']);
+            if (!in_array(self::REQUIRED_SCOPE, $granted_scopes, true)) {
+                return [
+                    'scope_error'    => true,
+                    'granted_scopes' => $granted_scopes,
+                ];
+            }
+        }
+
+        // Extract accountId from the 'account' object if present.
+        // Alignment: Claude CLI's token response contains 'account' => ['uuid' => ..., 'email_address' => ...].
+        $account_id = null;
+        if (!empty($data['account']) && is_array($data['account'])) {
+            $account_id = $data['account']['uuid'] ?? null;
+        }
+
         $result = [
             'access_token'  => $data['access_token'],
             'refresh_token' => $data['refresh_token'] ?? '',
             'expires_in'    => (int) ($data['expires_in'] ?? 3600),
         ];
 
-        // Store in pool.
-        $this->addAccount($email, $result['access_token'], $result['refresh_token'], $result['expires_in']);
+        // Store in pool, including accountId if available.
+        $this->addAccount(
+            $email,
+            $result['access_token'],
+            $result['refresh_token'],
+            $result['expires_in'],
+            $account_id
+        );
 
         return $result;
     }
@@ -585,5 +796,35 @@ class PoolManager
     {
         $hash = hash('sha256', $verifier, true);
         return rtrim(strtr(base64_encode($hash), '+/', '-_'), '=');
+    }
+
+    /**
+     * Parses the Retry-After header from a wp_remote_* response.
+     *
+     * Supports both integer (seconds) and HTTP-date formats per RFC 7231.
+     * Returns null if the header is absent or unparseable.
+     *
+     * @param array $response The wp_remote_* response array.
+     * @return int|null Retry-After in seconds, or null if not present.
+     */
+    protected function parseRetryAfter(array $response): ?int
+    {
+        $header = wp_remote_retrieve_header($response, 'retry-after');
+        if (empty($header)) {
+            return null;
+        }
+
+        // Integer seconds format: "Retry-After: 60"
+        if (ctype_digit((string) $header)) {
+            return (int) $header;
+        }
+
+        // HTTP-date format: "Retry-After: Wed, 21 Oct 2025 07:28:00 GMT"
+        $timestamp = strtotime((string) $header);
+        if ($timestamp !== false && $timestamp > time()) {
+            return $timestamp - time();
+        }
+
+        return null;
     }
 }

--- a/src/OAuthPool/TokenRefresher.php
+++ b/src/OAuthPool/TokenRefresher.php
@@ -45,7 +45,7 @@ class TokenRefresher
             [
                 'headers' => [
                     'Content-Type' => 'application/json',
-                    'User-Agent'   => 'ai-provider-for-anthropic-max/1.0.0',
+                    'User-Agent'   => PoolManager::USER_AGENT,
                 ],
                 'body'    => $body,
                 'timeout' => 15,


### PR DESCRIPTION
## Summary

Incorporates six alignment improvements identified by comparing the plugin against the aidevops `oauth-pool-helper.sh` reference implementation.

## Changes

### High priority

**Retry-After header support (429/529)**
- `PoolManager::markRateLimited()` now accepts a `$retry_after_secs` parameter that overrides the fixed 5-minute default cooldown.
- New `PoolManager::markRateLimitedFromResponse()` helper parses `Retry-After` (integer seconds or HTTP-date per RFC 7231) from a `wp_remote_*` response.
- `AnthropicMaxTextGenerationModel::generateTextResult()` intercepts 429/529 responses before throwing, calls `handleRateLimitResponse()` to mark the active account with the server-specified cooldown.
- `AnthropicOAuthRequestAuthentication` now tracks the active account email via `getActiveEmail()` so the model can identify which account to mark.
- `PoolManager::getActiveTokenWithEmail()` returns `{token, email}` together to avoid a second pool lookup.

### Medium priority

**accountId storage**
- `PoolManager::addAccount()` accepts an optional `$account_id` parameter (the `account.uuid` from the token response).
- `exchangeCode()` extracts `account.uuid` from the `account` object in the token response and passes it to `addAccount()`.
- `listAccounts()` and `healthCheck()` expose `accountId` in their output for diagnostics.

**user:inference scope validation**
- `exchangeCode()` checks the `scope` field in the token response against `user:inference` before adding the account to the pool.
- Returns `['scope_error' => true, 'granted_scopes' => [...]]` on failure (account is NOT added).
- REST `rest_exchange_code()` maps this to HTTP 403 with a clear message prompting re-authorization.

### Low priority

**User-Agent alignment**
- Token exchange and refresh requests now send `claude-cli/2.1.80 (wordpress-plugin)` via `PoolManager::USER_AGENT`, matching the Claude CLI format.
- `TokenRefresher` references `PoolManager::USER_AGENT` instead of a hardcoded string.

**Fallback URL comments**
- `PoolManager` constants block now documents the `platform.claude.com/oauth/code/callback` fallback redirect URI and the `claude.com/cai/oauth/authorize` fallback authorize URL, matching the notes in `oauth-pool-helper.sh`.

**login_hint / login_method / org_uuid**
- `PoolManager::startOAuthFlow()` accepts optional `$login_hint`, `$login_method`, and `$org_uuid` parameters, appending them to the authorize URL when provided.
- The `/authorize` REST endpoint exposes these as optional query params with validation.

## Testing

All five modified files pass `php -l` syntax check. Functional testing requires a WordPress environment with a Claude Max account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth authorization now accepts optional login hint, login method preference, and organization UUID
  * Active account email is tracked for OAuth sessions
  * Automatic rate-limit detection using Retry-After header to record cooldowns

* **Bug Fixes**
  * Improved handling when granted OAuth scopes are insufficient: returns a 403 with granted-scope details and re-authorization guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->