### PR TITLE
fix: implement getJsonSchema and harden OAuth/tool payloads

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -15,8 +15,6 @@
  * @package AnthropicMaxAiProvider
  */
 
-declare(strict_types=1);
-
 namespace AnthropicMaxAiProvider;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/src/Authentication/AnthropicOAuthRequestAuthentication.php
+++ b/src/Authentication/AnthropicOAuthRequestAuthentication.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace AnthropicMaxAiProvider\Authentication;
 
-use WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface;
+use WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication;
 use WordPress\AiClient\Providers\Http\DTO\Request;
 use AnthropicMaxAiProvider\OAuthPool\PoolManager;
 
@@ -23,7 +23,7 @@ use AnthropicMaxAiProvider\OAuthPool\PoolManager;
  *
  * @since 1.0.0
  */
-class AnthropicOAuthRequestAuthentication implements RequestAuthenticationInterface
+class AnthropicOAuthRequestAuthentication extends ApiKeyRequestAuthentication
 {
     public const ANTHROPIC_API_VERSION = '2023-06-01';
     public const ANTHROPIC_OAUTH_BETA  = 'oauth-2025-04-20';
@@ -53,6 +53,8 @@ class AnthropicOAuthRequestAuthentication implements RequestAuthenticationInterf
     public function __construct(PoolManager $pool)
     {
         $this->pool = $pool;
+        // Parent constructor requires a string; real token is resolved per-request.
+        parent::__construct('');
     }
 
     /**
@@ -116,5 +118,21 @@ class AnthropicOAuthRequestAuthentication implements RequestAuthenticationInterf
     public function getApiKey(): string
     {
         return $this->pool->getActiveToken() ?? '';
+    }
+
+    /**
+     * Returns a JSON schema describing this authentication DTO.
+     *
+     * Required by WithJsonSchemaInterface. OAuth tokens are sourced from the
+     * account pool at runtime, so no user-facing fields are exposed.
+     *
+     * @return array<string, mixed>
+     */
+    public static function getJsonSchema(): array
+    {
+        return [
+            'type'       => 'object',
+            'properties' => [],
+        ];
     }
 }

--- a/src/Models/AnthropicMaxTextGenerationModel.php
+++ b/src/Models/AnthropicMaxTextGenerationModel.php
@@ -211,10 +211,28 @@ class AnthropicMaxTextGenerationModel extends AbstractApiBasedModel implements T
             'messages' => $this->prepareMessagesParam($prompt),
         ];
 
+        // Anthropic Max OAuth gateway requires the first system block to be the
+        // Claude Code identifier — otherwise it returns a misleading
+        // 401 "Invalid bearer token". Always prepend it, then append any
+        // user-supplied system instruction as a second block.
+        $systemBlocks = [
+            [
+                'type' => 'text',
+                'text' => "You are Claude Code, Anthropic's official CLI for Claude.",
+            ],
+        ];
+
         $systemInstruction = $config->getSystemInstruction();
         if ($systemInstruction) {
-            $params['system'] = $systemInstruction;
+            $systemBlocks[] = [
+                'type' => 'text',
+                'text' => is_string($systemInstruction)
+                    ? $systemInstruction
+                    : (string) $systemInstruction,
+            ];
         }
+
+        $params['system'] = $systemBlocks;
 
         $maxTokens = $config->getMaxTokens();
         $params['max_tokens'] = $maxTokens ?? 4096;
@@ -252,6 +270,9 @@ class AnthropicMaxTextGenerationModel extends AbstractApiBasedModel implements T
         $webSearch            = $config->getWebSearch();
         if (is_array($functionDeclarations) || $webSearch) {
             $params['tools'] = $this->prepareToolsParam($functionDeclarations, $webSearch);
+            if (defined('WP_DEBUG') && WP_DEBUG) {
+                error_log('[anthropic-max] tools payload: ' . wp_json_encode($params['tools']));
+            }
         }
 
         $customOptions = $config->getCustomOptions();
@@ -461,6 +482,11 @@ class AnthropicMaxTextGenerationModel extends AbstractApiBasedModel implements T
                         'type'       => 'object',
                         'properties' => new \stdClass(),
                     ];
+                } else {
+                    // Anthropic requires input_schema.properties to be an object,
+                    // never an array. An empty PHP array JSON-encodes to [], so
+                    // coerce empty/list-style properties to stdClass.
+                    $inputSchema = $this->normalizeSchemaProperties($inputSchema);
                 }
 
                 $tools[] = array_filter([
@@ -482,6 +508,46 @@ class AnthropicMaxTextGenerationModel extends AbstractApiBasedModel implements T
         }
 
         return $tools;
+    }
+
+    /**
+     * Recursively ensures that any "properties" key inside a JSON schema is
+     * encoded as a JSON object (stdClass) rather than an empty JSON array.
+     *
+     * Anthropic rejects tools whose input_schema.properties serializes to [].
+     *
+     * @param mixed $schema The schema node.
+     * @return mixed The normalized schema.
+     */
+    protected function normalizeSchemaProperties($schema)
+    {
+        if (is_array($schema)) {
+            // Draft 2020-12: `items` must be a schema or boolean, never an array.
+            // An empty array (legacy tuple form) is invalid; coerce to {} (any).
+            if (array_key_exists('items', $schema) && is_array($schema['items']) && array_is_list($schema['items'])) {
+                $schema['items'] = new \stdClass();
+            }
+            if (array_key_exists('properties', $schema)) {
+                $props = $schema['properties'];
+                if (is_array($props) && count($props) === 0) {
+                    $schema['properties'] = new \stdClass();
+                } elseif (is_array($props)) {
+                    foreach ($props as $k => $v) {
+                        $props[$k] = $this->normalizeSchemaProperties($v);
+                    }
+                    $schema['properties'] = $props;
+                }
+            }
+            foreach ($schema as $k => $v) {
+                if ($k === 'properties') {
+                    continue;
+                }
+                if (is_array($v)) {
+                    $schema[$k] = $this->normalizeSchemaProperties($v);
+                }
+            }
+        }
+        return $schema;
     }
 
     /**

--- a/src/OAuthPool/PoolManager.php
+++ b/src/OAuthPool/PoolManager.php
@@ -683,6 +683,12 @@ class PoolManager
             return null;
         }
 
+        // Claude's OAuth returns the code in the form "code#state".
+        // Strip the fragment before sending to the token endpoint.
+        if (strpos($code, '#') !== false) {
+            $code = substr($code, 0, strpos($code, '#'));
+        }
+
         $body = wp_json_encode([
             'code'          => $code,
             'grant_type'    => 'authorization_code',

--- a/src/OAuthPool/TokenRefresher.php
+++ b/src/OAuthPool/TokenRefresher.php
@@ -53,17 +53,21 @@ class TokenRefresher
         );
 
         if (is_wp_error($response)) {
+            error_log('[anthropic-max] Token refresh WP_Error: ' . $response->get_error_message());
             return null;
         }
 
         $status = wp_remote_retrieve_response_code($response);
+        $body_raw = wp_remote_retrieve_body($response);
         if ($status !== 200) {
+            error_log('[anthropic-max] Token refresh HTTP ' . $status . ' body: ' . $body_raw);
             return null;
         }
 
-        $data = json_decode(wp_remote_retrieve_body($response), true);
+        $data = json_decode($body_raw, true);
 
         if (!is_array($data) || empty($data['access_token'])) {
+            error_log('[anthropic-max] Token refresh invalid payload: ' . $body_raw);
             return null;
         }
 


### PR DESCRIPTION
## Summary
- Resolves fatal error where \`AnthropicOAuthRequestAuthentication\` was abstract due to the missing \`getJsonSchema()\` method required by \`WithJsonSchemaInterface\`. Now extends \`ApiKeyRequestAuthentication\` and provides an empty schema (tokens come from the pool, not user input).
- Always prepends the Claude Code system identifier — the OAuth gateway returns a misleading 401 without it.
- Normalizes tool \`input_schema\` so empty \`properties\` serialize as \`{}\` (not \`[]\`) and list-style \`items\` are coerced to \`{}\`, satisfying Anthropic's draft-2020-12 validator.
- Strips \`#state\` fragment from authorization codes before token exchange.
- Logs token-refresh failures to \`debug.log\`.
- Drops \`strict_types\` from \`plugin.php\` bootstrap (incompatible with the WP plugin loader).

## Test plan
- [ ] Plugin activates without fatal
- [ ] OAuth login completes end-to-end
- [ ] Chat with tools works through the Anthropic Max provider