### PR TITLE
v1.1.0: rename provider id to ultimate-ai-connector-anthropic-max + fix render clobber

### DIFF
--- a/js/connector.jsx
+++ b/js/connector.jsx
@@ -521,10 +521,34 @@ function AnthropicMaxConnectorCard( { slug, label, description } ) {
 }
 
 // Register the connector card.
-registerConnector( 'ai-provider-for-anthropic-max/connector', {
+const SLUG = 'ai-provider-for-anthropic-max/connector';
+const CONFIG = {
 	label: __( 'Anthropic Max' ),
 	description: __(
 		'Use Claude with your Max subscription via OAuth. Supports account pool rotation for reliability.'
 	),
 	render: AnthropicMaxConnectorCard,
-} );
+};
+
+// WP core's `routes/connectors-home/content` module runs
+// `registerDefaultConnectors()` from inside an async dynamic import. By the
+// time it executes, our top-level registerConnector() has already populated
+// the store — and the store reducer spreads new config over existing
+// entries, so the default's `args.render = ApiKeyConnector` can overwrite
+// our custom render. We currently dodge this by using a slug that doesn't
+// collide with the PHP-side provider id, but that's fragile (a future
+// upstream change to slug normalization could break it). The proper fix is
+// in WordPress/gutenberg#77116; until that ships we re-assert our
+// registration on five ticks (sync + microtask + setTimeout 0/50/250/1000ms)
+// as defense in depth so our render always ends up last regardless of
+// dynamic-import resolution order.
+function registerOurs() {
+	registerConnector( SLUG, CONFIG );
+}
+
+registerOurs();
+Promise.resolve().then( registerOurs );
+setTimeout( registerOurs, 0 );
+setTimeout( registerOurs, 50 );
+setTimeout( registerOurs, 250 );
+setTimeout( registerOurs, 1000 );

--- a/js/connector.jsx
+++ b/js/connector.jsx
@@ -509,7 +509,7 @@ function AnthropicMaxConnectorCard( { slug, label, description } ) {
 
 	return (
 		<ConnectorItem
-			className="connector-item--anthropic-max"
+			className="connector-item--ultimate-ai-connector-anthropic-max"
 			icon={ <Logo /> }
 			name={ label }
 			description={ description }
@@ -521,7 +521,11 @@ function AnthropicMaxConnectorCard( { slug, label, description } ) {
 }
 
 // Register the connector card.
-const SLUG = 'ai-provider-for-anthropic-max/connector';
+//
+// SLUG matches the PHP provider id from AnthropicMaxProvider::createProviderMetadata()
+// so the WP core Connectors page renders ONE card instead of two (the
+// auto-discovered server entry + a separately-keyed JS entry).
+const SLUG = 'ultimate-ai-connector-anthropic-max';
 const CONFIG = {
 	label: __( 'Anthropic Max' ),
 	description: __(
@@ -534,14 +538,12 @@ const CONFIG = {
 // `registerDefaultConnectors()` from inside an async dynamic import. By the
 // time it executes, our top-level registerConnector() has already populated
 // the store — and the store reducer spreads new config over existing
-// entries, so the default's `args.render = ApiKeyConnector` can overwrite
-// our custom render. We currently dodge this by using a slug that doesn't
-// collide with the PHP-side provider id, but that's fragile (a future
-// upstream change to slug normalization could break it). The proper fix is
-// in WordPress/gutenberg#77116; until that ships we re-assert our
-// registration on five ticks (sync + microtask + setTimeout 0/50/250/1000ms)
-// as defense in depth so our render always ends up last regardless of
-// dynamic-import resolution order.
+// entries, so the default's `args.render = ApiKeyConnector` would overwrite
+// our custom render. The proper fix is in WordPress/gutenberg#77116; until
+// that ships we re-assert our registration on five ticks (sync + microtask
+// + setTimeout 0/50/250/1000ms) so our render always ends up last regardless
+// of dynamic-import resolution order. Re-registering with the same render
+// reference is idempotent so the redundant calls cost essentially nothing.
 function registerOurs() {
 	registerConnector( SLUG, CONFIG );
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ai-provider-for-anthropic-max",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "private": true,
     "license": "GPL-2.0-or-later",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ai-provider-for-anthropic-max",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "private": true,
     "license": "GPL-2.0-or-later",
     "scripts": {

--- a/plugin.php
+++ b/plugin.php
@@ -5,7 +5,7 @@
  * Description: Anthropic provider for the WordPress AI Client using Claude Max OAuth tokens with account pool rotation.
  * Requires at least: 6.9
  * Requires PHP: 7.4
- * Version: 1.0.1
+ * Version: 1.1.0
  * Author: Ultimate Multisite Community
  * Author URI: https://ultimatemultisite.com
  * License: GPL-2.0-or-later
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	return;
 }
 
-define( 'ANTHROPIC_MAX_AI_PROVIDER_VERSION', '1.0.1' );
+define( 'ANTHROPIC_MAX_AI_PROVIDER_VERSION', '1.1.0' );
 
 // ---------------------------------------------------------------------------
 // PSR-4 autoloader for src/ classes.

--- a/plugin.php
+++ b/plugin.php
@@ -5,7 +5,7 @@
  * Description: Anthropic provider for the WordPress AI Client using Claude Max OAuth tokens with account pool rotation.
  * Requires at least: 6.9
  * Requires PHP: 7.4
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: Ultimate Multisite Community
  * Author URI: https://ultimatemultisite.com
  * License: GPL-2.0-or-later
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	return;
 }
 
-define( 'ANTHROPIC_MAX_AI_PROVIDER_VERSION', '1.0.0' );
+define( 'ANTHROPIC_MAX_AI_PROVIDER_VERSION', '1.0.1' );
 
 // ---------------------------------------------------------------------------
 // PSR-4 autoloader for src/ classes.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: superdav42
 Tags: ai, anthropic, claude, oauth, max
 Requires at least: 6.9
 Tested up to: 7.0
-Stable tag: 1.0.1
+Stable tag: 1.1.0
 Requires PHP: 7.4
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -65,9 +65,11 @@ OAuth tokens are stored in the WordPress options table. Only site administrators
 
 == Changelog ==
 
-= 1.0.1 =
+= 1.1.0 =
 
-* Defensive: re-assert our `registerConnector()` call across multiple ticks (microtask + 0/50/250/1000 ms) so the WP core `registerDefaultConnectors()` auto-register can't clobber the custom card with the generic API-key UI. Today this plugin happens to escape the bug because its JS slug doesn't collide with the PHP-side provider id, but that's fragile. The proper upstream fix is in https://github.com/WordPress/gutenberg/pull/77116 — once that ships in a Gutenberg release, this defense can be removed.
+* **BREAKING**: renamed the AI Client provider id from `anthropic-max` to `ultimate-ai-connector-anthropic-max` for consistency with the sister plugins (`ultimate-ai-connector-webllm`, `ultimate-ai-connector-compatible-endpoints`) and to claim the namespace properly. Code that called `AiClient::defaultRegistry()->getProvider('anthropic-max')` must update the id. Stored OAuth tokens, REST endpoints, and option keys are unchanged so existing setups continue to work.
+* Improved: the JS-side `registerConnector()` slug now matches the PHP provider id, so the WP core Connectors page renders one card instead of two (a previously-hidden duplicate auto-registered card with the generic API-key form is now suppressed).
+* Fix: re-assert our `registerConnector()` call across multiple ticks (microtask + 0/50/250/1000 ms) so the WP core `registerDefaultConnectors()` auto-register can't clobber the custom card with the generic API-key UI. Necessary because matching the slug exposes us to the same race the other Ultimate-Multisite connector plugins hit. The proper upstream fix is in https://github.com/WordPress/gutenberg/pull/77116 — once that ships in a Gutenberg release, this workaround can be removed.
 
 = 1.0.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: superdav42
 Tags: ai, anthropic, claude, oauth, max
 Requires at least: 6.9
 Tested up to: 7.0
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 Requires PHP: 7.4
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -64,6 +64,10 @@ Multiple accounts provide failover. If one account hits a rate limit, the plugin
 OAuth tokens are stored in the WordPress options table. Only site administrators with `manage_options` capability can manage the account pool.
 
 == Changelog ==
+
+= 1.0.1 =
+
+* Defensive: re-assert our `registerConnector()` call across multiple ticks (microtask + 0/50/250/1000 ms) so the WP core `registerDefaultConnectors()` auto-register can't clobber the custom card with the generic API-key UI. Today this plugin happens to escape the bug because its JS slug doesn't collide with the PHP-side provider id, but that's fragile. The proper upstream fix is in https://github.com/WordPress/gutenberg/pull/77116 — once that ships in a Gutenberg release, this defense can be removed.
 
 = 1.0.0 =
 

--- a/src/Provider/AnthropicMaxProvider.php
+++ b/src/Provider/AnthropicMaxProvider.php
@@ -2,8 +2,8 @@
 /**
  * Anthropic Max provider for the WordPress AI Client.
  *
- * Registers as a separate provider ('anthropic-max') so it can coexist
- * with the standard API-key-based Anthropic provider.
+ * Registers as a separate provider ('ultimate-ai-connector-anthropic-max')
+ * so it can coexist with the standard API-key-based Anthropic provider.
  *
  * @since 1.0.0
  *
@@ -77,17 +77,25 @@ class AnthropicMaxProvider extends AbstractApiProvider
     /**
      * Creates the provider metadata.
      *
-     * Uses 'anthropic-max' as the provider ID to avoid conflicts
-     * with the standard API-key-based Anthropic provider.
+     * Uses 'ultimate-ai-connector-anthropic-max' as the provider ID. The
+     * `ultimate-ai-connector-` namespace matches the sister plugins
+     * (`ultimate-ai-connector-webllm`, `ultimate-ai-connector-compatible-endpoints`)
+     * and avoids any future collision with another plugin author who might
+     * register a generic 'anthropic-max' provider id.
      *
-     * @since 1.0.0
+     * @since 1.0.0 As 'anthropic-max'.
+     * @since 1.1.0 Renamed to 'ultimate-ai-connector-anthropic-max' for
+     *              consistency with other Ultimate-Multisite connector plugins
+     *              and to make the JS-side `registerConnector()` slug match
+     *              this id (so the WP core Connectors page renders one card
+     *              instead of two).
      *
      * @return ProviderMetadata
      */
     protected static function createProviderMetadata(): ProviderMetadata
     {
         $args = [
-            'anthropic-max',
+            'ultimate-ai-connector-anthropic-max',
             'Anthropic Max',
             ProviderTypeEnum::cloud(),
             null,


### PR DESCRIPTION
## Summary

Two coordinated changes that have to ship together to fix the Connectors page properly.

### 1. Rename the provider id (BREAKING)

| | Old | New |
|---|---|---|
| PHP `createProviderMetadata()` first arg | `'anthropic-max'` | `'ultimate-ai-connector-anthropic-max'` |
| JS `registerConnector()` slug | `'ai-provider-for-anthropic-max/connector'` | `'ultimate-ai-connector-anthropic-max'` |
| Rendered `ConnectorItem` className | `connector-item--anthropic-max` | `connector-item--ultimate-ai-connector-anthropic-max` |

Why:

- **Consistency** with the sister plugins `ultimate-ai-connector-webllm` and `ultimate-ai-connector-compatible-endpoints` that both follow the `ultimate-ai-connector-{name}` naming.
- **Namespace claim**: `anthropic-max` is generic enough that another plugin author could easily collide with it. `ultimate-ai-connector-anthropic-max` reserves the name properly.
- **One card on the Connectors page** instead of two. Previously the JS-side slug differed from the PHP-side provider id, so WP core's `registerDefaultConnectors()` was creating a *separate* auto-registered entry with the generic API-key form alongside our custom card. The duplicate was just visually hidden in most layouts. Matching the slugs collapses them into a single store entry.

This is a **breaking change** for any caller that hardcoded the old id, e.g. `AiClient::defaultRegistry()->getProvider('anthropic-max')`. Things that are deliberately *not* changed to keep upgrades safe:

- Stored OAuth tokens (`anthropic_max_oauth_pool` option)
- PKCE transient prefix (`anthropic_max_pkce_`)
- REST endpoint namespace (`anthropic-max-pool/v1`)
- Plugin folder, text domain, composer/npm package names, error log prefixes

### 2. 5-tick `registerConnector()` re-assertion (workaround)

Once the slugs match, this plugin is exposed to the same race the other Ultimate-Multisite connector plugins hit:

- WP core's `routes/connectors-home/content` module runs `registerDefaultConnectors()` from inside an async dynamic import.
- By the time it executes, our top-level `registerConnector()` has already populated the store.
- The store reducer in `@wordpress/connectors` spreads new config over existing entries, so the default's `args.render = ApiKeyConnector` overwrites our custom render and the user sees the generic API-key form.

Re-assert the registration on five ticks (sync + microtask + setTimeout at 0/50/250/1000 ms) so we always end up last regardless of dynamic-import resolution order. Idempotent so the redundant calls cost essentially nothing.

The proper upstream fix is **WordPress/gutenberg#77116** (already opened, makes `registerDefaultConnectors()` skip slugs that already have a custom render). Once that ships in a Gutenberg release, the workaround can be removed; the rename in (1) is permanent.

## Test plan

- [x] Activate this branch on a clean WordPress 7.0 install with the AI plugin loaded.
- [x] Visit **Settings → Connectors** and verify exactly one "Anthropic Max" card is rendered, showing the OAuth pool form (not the generic API-key form).
- [x] Open the Anthropic Max card, walk through the OAuth flow, add an account, run a health check — all should work as before. Existing OAuth tokens from v1.0.0 should still authenticate (no migration needed because the option keys are unchanged).
- [x] Verify against other connector plugins active simultaneously (load-order shifts should no longer affect rendering).

## Release

Bumps version **1.0.0 → 1.1.0** in:
- `plugin.php` header + `ANTHROPIC_MAX_AI_PROVIDER_VERSION` constant
- `package.json`
- `readme.txt` Stable tag + new changelog entry (marked with **BREAKING**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Anthropic Max connector with improved UI registration and display stability.

* **Chores**
  * Bumped plugin version to 1.1.0.
  * Updated provider identifier; API users should review integration points for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->