### PR TITLE
fix: surface actual server error in OAuth code exchange UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md — ai-provider-for-anthropic-max
+
+WordPress plugin.
+
+## Local Development Environment
+
+The shared WordPress dev install for testing this plugin is at `../wordpress` (relative to this repo root).
+
+- **URL**: http://wordpress.local:8080
+- **Admin**: http://wordpress.local:8080/wp-admin — `admin` / `admin`
+- **WordPress version**: 7.0-RC2
+- **This plugin**: symlinked into `../wordpress/wp-content/plugins/$(basename $PWD)`
+- **Reset to clean state**: `cd ../wordpress && ./reset.sh`
+
+WP-CLI is configured via `wp-cli.yml` in this repo root — run `wp` commands directly from here without specifying `--path`.
+
+```bash
+wp plugin activate $(basename $PWD)   # activate this plugin
+wp plugin deactivate $(basename $PWD) # deactivate
+wp db reset --yes && cd ../wordpress && ./reset.sh  # full reset
+```

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -23,16 +23,21 @@ if ( ! defined( 'ABSPATH' ) ) {
  * is loaded only where it is needed.
  */
 function enqueue_connector_module(): void {
+	$asset_file = __DIR__ . '/../build/connector.js';
+	$version     = file_exists( $asset_file )
+		? filemtime( $asset_file )
+		: ANTHROPIC_MAX_AI_PROVIDER_VERSION;
+
 	wp_register_script_module(
 		'ai-provider-for-anthropic-max',
-		plugins_url( 'build/connector.js', __DIR__ ),
+		ANTHROPIC_MAX_AI_PROVIDER_URL . 'build/connector.js',
 		[
 			[
 				'id'     => '@wordpress/connectors',
 				'import' => 'static',
 			],
 		],
-		ANTHROPIC_MAX_AI_PROVIDER_VERSION
+		$version
 	);
 	wp_enqueue_script_module( 'ai-provider-for-anthropic-max' );
 }

--- a/js/connector.jsx
+++ b/js/connector.jsx
@@ -178,11 +178,9 @@ function AddAccountForm( { onComplete, onCancel } ) {
 			window.open( data.authorize_url, '_blank', 'noopener' );
 			setStep( 'code' );
 		} catch ( err ) {
-			setError(
-				err instanceof Error
-					? err.message
-					: __( 'Failed to start OAuth flow.' )
-			);
+			// apiFetch throws a plain object {code, message, data} for WP_Error responses,
+			// not an Error instance. Use err?.message to surface the actual server message.
+			setError( err?.message || __( 'Failed to start OAuth flow.' ) );
 		} finally {
 			setIsBusy( false );
 		}
@@ -207,11 +205,9 @@ function AddAccountForm( { onComplete, onCancel } ) {
 			} );
 			onComplete();
 		} catch ( err ) {
-			setError(
-				err instanceof Error
-					? err.message
-					: __( 'Code exchange failed.' )
-			);
+			// apiFetch throws a plain object {code, message, data} for WP_Error responses,
+			// not an Error instance. Use err?.message to surface the actual server message.
+			setError( err?.message || __( 'Code exchange failed.' ) );
 		} finally {
 			setIsBusy( false );
 		}

--- a/plugin.php
+++ b/plugin.php
@@ -24,6 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'ANTHROPIC_MAX_AI_PROVIDER_VERSION', '1.0.0' );
+define( 'ANTHROPIC_MAX_AI_PROVIDER_URL', plugin_dir_url( __FILE__ ) );
 
 // ---------------------------------------------------------------------------
 // PSR-4 autoloader for src/ classes.

--- a/src/OAuthPool/PoolManager.php
+++ b/src/OAuthPool/PoolManager.php
@@ -705,16 +705,25 @@ class PoolManager
         );
 
         if (is_wp_error($response)) {
+            if (defined('WP_DEBUG') && WP_DEBUG) {
+                error_log('[AnthropicMax] Token exchange wp_error: ' . $response->get_error_message());
+            }
             return null;
         }
 
         $status = wp_remote_retrieve_response_code($response);
         if ($status !== 200) {
+            if (defined('WP_DEBUG') && WP_DEBUG) {
+                error_log('[AnthropicMax] Token exchange HTTP ' . $status . ': ' . wp_remote_retrieve_body($response));
+            }
             return null;
         }
 
         $data = json_decode(wp_remote_retrieve_body($response), true);
         if (!is_array($data) || empty($data['access_token'])) {
+            if (defined('WP_DEBUG') && WP_DEBUG) {
+                error_log('[AnthropicMax] Token exchange bad response body: ' . wp_remote_retrieve_body($response));
+            }
             return null;
         }
 

--- a/wp-cli.yml
+++ b/wp-cli.yml
@@ -1,0 +1,2 @@
+path: ../wordpress
+url: http://wordpress.local:8080


### PR DESCRIPTION
## Problem

After commit e1f3833 (scope validation), the OAuth code exchange can now fail with a 403 `insufficient_scope` error in addition to the existing 400 `exchange_failed` path. Both failures show the generic **"Code exchange failed."** message in the UI because the error handling used `err instanceof Error` — but `apiFetch` throws a plain object `{code, message, data}` for WP_Error responses, not an `Error` instance. The `instanceof` check always evaluated to `false`, swallowing the actual server message.

## Changes

**`js/connector.jsx`** — replace `err instanceof Error ? err.message : fallback` with `err?.message || fallback` in both `handleStartOAuth` and `handleExchangeCode`. This surfaces the actual server error (e.g. the scope validation message) instead of the generic fallback.

**`src/OAuthPool/PoolManager.php`** — add `WP_DEBUG` `error_log` calls in `exchangeCode()` at each null-return point (wp_error, non-200 HTTP status, bad response body). Enables diagnosis of token endpoint failures without modifying production code.

## Diagnosis

If you're seeing "Code exchange failed." after this PR, enable `WP_DEBUG` in `wp-config.php` and check the PHP error log. You'll see one of:
- `[AnthropicMax] Token exchange HTTP 400: {"error":"invalid_grant",...}` — code is expired or already used
- `[AnthropicMax] Token exchange HTTP 4xx: ...` — token endpoint rejected the request
- `[AnthropicMax] Token exchange bad response body: ...` — unexpected response format

If the exchange succeeds (200) but scope validation fails, the UI will now show the full message: *"Authorization succeeded but the token is missing the required 'user:inference' scope..."* — which means the account doesn't have a Claude Max subscription.

## Testing

1. Enable `WP_DEBUG` in `wp-config.php`
2. Go through the OAuth flow with an invalid/expired code — the UI should now show the actual error from the server
3. Go through the OAuth flow with a valid code from a non-Max account — the UI should show the scope error message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive developer guide for WordPress plugin development environment setup, including local installation configuration, site access URLs, WordPress version specifications, and WP-CLI command examples.

* **Bug Fixes**
  * Improved error message handling in OAuth account connection to provide clearer feedback when authentication fails.

* **Chores**
  * Enhanced diagnostic logging for OAuth token exchange operations to support troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->