### PR TITLE
GH#8: Commit build/ directory so plugin works from git source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 vendor/
 node_modules/
-build/
 *.zip
 .wp-env.override.json
 .agents/loop-state/


### PR DESCRIPTION
## Summary

- Removes `build/` from `.gitignore` so the webpack output is explicitly tracked in git
- `build/connector.js` was already committed (force-added in prior commit `750fb9f`); this makes the tracking intentional and consistent
- The admin settings page enqueues from `build/connector.js` (see `inc/admin.php:28`), which is now properly tracked for WordPress Playground `git:directory` installs

## Why

The WordPress Playground blueprint uses `git:directory` to install plugins directly from source. Without `build/connector.js` committed and `.gitignore` updated, the compiled JS is absent and the admin settings page fails to render.

## Runtime Testing

**Risk level:** Low — this is a `.gitignore` and build artifact change, no logic changes.

Verified:
- `npm run build` runs successfully and produces `build/connector.js` (11.1 KiB, minimized)
- `build/connector.js` is tracked: `git ls-files build/` confirms the file
- `inc/admin.php` enqueues from `plugins_url('build/connector.js', __DIR__)` — correct path
- `.gitignore` no longer excludes `build/`

## Resolves

Resolves #8

---
[aidevops.sh](https://aidevops.sh) v3.6.234 plugin for [OpenCode](https://opencode.ai) v1.3.16 with claude-sonnet-4-6 spent 3m and 5,894 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control configuration to include the `build/` directory in the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->