### PR TITLE
fix: replace sanitize_email with sanitize_text_field on DELETE/refresh routes

### DIFF
--- a/inc/rest-api.php
+++ b/inc/rest-api.php
@@ -107,7 +107,12 @@ function register_routes(): void {
 				'email' => [
 					'required'          => true,
 					'type'              => 'string',
-					'sanitize_callback' => 'sanitize_email',
+					// Use sanitize_text_field instead of sanitize_email: the email was
+					// already validated when the account was added. sanitize_email strips
+					// characters valid in some email addresses (e.g. underscores in domain
+					// subdomains, local-only domains) and returns '' for anything it
+					// considers invalid, causing the pool lookup to fail with a 404.
+					'sanitize_callback' => 'sanitize_text_field',
 				],
 			],
 		]
@@ -125,7 +130,8 @@ function register_routes(): void {
 				'email' => [
 					'required'          => true,
 					'type'              => 'string',
-					'sanitize_callback' => 'sanitize_email',
+					// Same rationale as the DELETE route above.
+					'sanitize_callback' => 'sanitize_text_field',
 				],
 			],
 		]

--- a/src/OAuthPool/PoolManager.php
+++ b/src/OAuthPool/PoolManager.php
@@ -145,6 +145,9 @@ class PoolManager
                 'hasRefresh'    => !empty($account['refresh']),
                 'cooldownUntil' => $account['cooldownUntil'] ?? null,
                 'accountId'     => $account['accountId'] ?? null,
+                // validity is not checked here (avoids an HTTP round-trip per account).
+                // Use the /health endpoint for token validation. null signals "not checked".
+                'validity'      => null,
             ];
         }, $accounts);
     }
@@ -401,7 +404,7 @@ class PoolManager
      * Removes an account from the pool by email.
      *
      * @param string $email The account email to remove.
-     * @return bool Whether an account was found and removed.
+     * @return bool Whether an account was found and successfully removed.
      */
     public function removeAccount(string $email): bool
     {
@@ -419,8 +422,7 @@ class PoolManager
             return false;
         }
 
-        $this->savePool($pool);
-        return true;
+        return $this->savePool($pool);
     }
 
     /**


### PR DESCRIPTION
## Root cause

`sanitize_email` was used as the `sanitize_callback` for the `email` URL path parameter on the `DELETE /accounts/{email}` and `POST /accounts/{email}/refresh` routes.

`sanitize_email` is a **validator**, not just a sanitizer — it returns `''` (empty string) for any email it considers invalid, including:
- Emails with underscores in domain subdomains (e.g. `user@my_company.com`)
- Local-only domains (e.g. `user@localhost`)
- Any email that fails its strict RFC-subset checks

When the sanitized value is `''`, `removeAccount('')` finds no account with email `''`, returns `false`, and the REST endpoint returns 404 `Account not found in pool.` — which the frontend surfaces as **"Failed to remove account."**

The email was already validated by `sanitize_email` when the account was added (via the `/exchange` endpoint). The DELETE and `/refresh` routes only need to look up an existing stored email, so `sanitize_text_field` is the correct callback.

## Changes

**`inc/rest-api.php`**
- `DELETE /accounts/{email}`: `sanitize_email` → `sanitize_text_field`
- `POST /accounts/{email}/refresh`: `sanitize_email` → `sanitize_text_field`

**`src/OAuthPool/PoolManager.php`**
- `removeAccount()`: now returns `savePool()`'s result instead of always `true` after a count change — surfaces DB-level save failures rather than silently ignoring them
- `listAccounts()`: adds `validity: null` to each account entry so the `StatusBadge` component receives a consistent field (`null` = not checked; use `/health` to validate tokens)

## Testing

- Accounts with standard emails (`user@example.com`) can be removed ✓
- Accounts with emails containing underscores in domain (`user@my_company.com`) can be removed ✓
- Refresh endpoint uses the same fix ✓
- No JS rebuild required (PHP-only changes; frontend already handles `validity: null`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Account listing API responses now include a validity field for each account
  * Enhanced parameter validation for account management endpoints
  * Improved account removal operation handling and documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->