### PR TITLE
chore: upgrade GitHub Actions from Node.js 20 to Node.js 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate version consistency
         run: |
@@ -49,9 +49,9 @@ jobs:
           echo "All five version locations match tag $TAG"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions to use Node.js 24 runtime, eliminating deprecation warnings ahead of the June 2, 2026 forced migration.

## Changes

- `actions/checkout@v4` → `actions/checkout@v6`
- `actions/setup-node@v4` → `actions/setup-node@v6` (also bumps `node-version: 20` → `24`)

`shivammathur/setup-php@v2` is already on Node 24 — no change needed.

The workflow uses `gh release create` directly (not `softprops/action-gh-release`), so no `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var is required.

## Runtime Testing

Risk: **Low** — CI/workflow config change only. No application code modified.

Verification: trigger a workflow run after merge and confirm no Node.js 20 deprecation warnings appear in annotations.

Resolves #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and deployment infrastructure to use newer versions of development tools and runtime environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->