### PR TITLE
t17: differentiate not-found vs save-failed in removeAccount()

### DIFF
--- a/inc/rest-api.php
+++ b/inc/rest-api.php
@@ -254,18 +254,31 @@ function rest_exchange_code( \WP_REST_Request $request ) {
 /**
  * Removes an account from the pool.
  *
+ * Maps PoolManager::REMOVE_NOT_FOUND → 404, REMOVE_SAVE_ERROR → 500,
+ * and REMOVE_OK → 200 so callers can distinguish "account did not exist"
+ * from "account was removed but the database write failed".
+ *
  * @param \WP_REST_Request $request The request object.
  * @return \WP_REST_Response|\WP_Error
  */
 function rest_remove_account( \WP_REST_Request $request ) {
-	$email = $request->get_param( 'email' );
-	$pool  = PoolManager::getInstance();
+	$email  = $request->get_param( 'email' );
+	$pool   = PoolManager::getInstance();
+	$result = $pool->removeAccount( $email );
 
-	if ( ! $pool->removeAccount( $email ) ) {
+	if ( $result === PoolManager::REMOVE_NOT_FOUND ) {
 		return new \WP_Error(
 			'not_found',
 			__( 'Account not found in pool.', 'ai-provider-for-anthropic-max' ),
 			[ 'status' => 404 ]
+		);
+	}
+
+	if ( $result === PoolManager::REMOVE_SAVE_ERROR ) {
+		return new \WP_Error(
+			'save_failed',
+			__( 'Account removed but could not be saved to the database.', 'ai-provider-for-anthropic-max' ),
+			[ 'status' => 500 ]
 		);
 	}
 

--- a/src/OAuthPool/PoolManager.php
+++ b/src/OAuthPool/PoolManager.php
@@ -75,6 +75,20 @@ class PoolManager
     public const REQUIRED_SCOPE = 'user:inference';
 
     /**
+     * Return statuses for removeAccount().
+     *
+     * REMOVE_NOT_FOUND  — no account with the given email exists in the pool.
+     * REMOVE_OK         — account was found, removed, and the pool was saved.
+     * REMOVE_SAVE_ERROR — account was found and removed from memory but the
+     *                     database save failed (DB-level persistence error).
+     *
+     * Callers should map REMOVE_NOT_FOUND → 404 and REMOVE_SAVE_ERROR → 500.
+     */
+    public const REMOVE_NOT_FOUND  = 'not_found';
+    public const REMOVE_OK         = 'ok';
+    public const REMOVE_SAVE_ERROR = 'save_error';
+
+    /**
      * Singleton instance.
      *
      * @var self|null
@@ -403,10 +417,15 @@ class PoolManager
     /**
      * Removes an account from the pool by email.
      *
+     * Returns one of the REMOVE_* class constants to distinguish outcomes:
+     *   - REMOVE_NOT_FOUND  — no account with the given email exists.
+     *   - REMOVE_OK         — account removed and pool saved successfully.
+     *   - REMOVE_SAVE_ERROR — account removed from memory but DB save failed.
+     *
      * @param string $email The account email to remove.
-     * @return bool Whether an account was found and successfully removed.
+     * @return string One of the REMOVE_* class constants.
      */
-    public function removeAccount(string $email): bool
+    public function removeAccount(string $email): string
     {
         $pool     = $this->loadPool();
         $original = count($pool['accounts']);
@@ -419,10 +438,10 @@ class PoolManager
         ));
 
         if (count($pool['accounts']) === $original) {
-            return false;
+            return self::REMOVE_NOT_FOUND;
         }
 
-        return $this->savePool($pool);
+        return $this->savePool($pool) ? self::REMOVE_OK : self::REMOVE_SAVE_ERROR;
     }
 
     /**


### PR DESCRIPTION
## Summary

Addresses the unresolved CodeRabbit feedback from PR #11: `removeAccount()` conflated "account not found" and "database save failed" by returning `false` for both, causing the REST handler to always return 404 for any failure.

## Changes

**`src/OAuthPool/PoolManager.php`**
- Add three class constants: `REMOVE_NOT_FOUND`, `REMOVE_OK`, `REMOVE_SAVE_ERROR`
- Change `removeAccount()` return type from `bool` to `string`
- Return `REMOVE_NOT_FOUND` when no matching account exists
- Return `REMOVE_OK` when account is removed and pool saved successfully
- Return `REMOVE_SAVE_ERROR` when account is removed from memory but `savePool()` fails

**`inc/rest-api.php`**
- Update `rest_remove_account()` to capture the string result from `removeAccount()`
- Map `REMOVE_NOT_FOUND` → HTTP 404 (unchanged behaviour)
- Map `REMOVE_SAVE_ERROR` → HTTP 500 (new — distinct from not-found)
- Map `REMOVE_OK` → HTTP 200

## Verification

PHP syntax clean on both files:
```
php -l src/OAuthPool/PoolManager.php  # No syntax errors
php -l inc/rest-api.php               # No syntax errors
```

Resolves #17