### PR TITLE
t18: fix CodeRabbit review feedback from PR #6

### DIFF
--- a/js/connector.jsx
+++ b/js/connector.jsx
@@ -657,14 +657,14 @@ function AnthropicMaxConnectorCard( { slug, label, description, logo } ) {
 // so the WP core Connectors page renders ONE card instead of two (the
 // auto-discovered server entry + a separately-keyed JS entry).
 const SLUG = 'ultimate-ai-connector-anthropic-max';
-const CONFIG = {
+const CONFIG = Object.freeze( {
 	label: __( 'Anthropic Max' ),
 	description: __(
 		'Use Claude with your Max subscription via OAuth. Supports account pool rotation for reliability.'
 	),
 	logo: <Logo />,
 	render: AnthropicMaxConnectorCard,
-};
+} );
 
 // WP core's `routes/connectors-home/content` module runs
 // `registerDefaultConnectors()` from inside an async dynamic import. By the

--- a/readme.txt
+++ b/readme.txt
@@ -36,7 +36,7 @@ This plugin extends the WordPress AI Client to support **Anthropic Claude** usin
 5. Paste the authorization code back into the settings.
 6. Repeat to add more accounts for pool rotation.
 
-The plugin registers as a separate provider (`anthropic-max`) and coexists with the standard API-key-based Anthropic provider.
+The plugin registers as a separate provider (`ultimate-ai-connector-anthropic-max`) and coexists with the standard API-key-based Anthropic provider.
 
 == Installation ==
 
@@ -53,7 +53,7 @@ Claude Max is Anthropic's premium subscription plan that provides access to Clau
 
 = Can I use this alongside the standard Anthropic provider? =
 
-Yes. This plugin registers as "Anthropic Max" (`anthropic-max`), separate from the standard "Anthropic" (`anthropic`) provider. Both can be active simultaneously.
+Yes. This plugin registers as "Anthropic Max" (`ultimate-ai-connector-anthropic-max`), separate from the standard "Anthropic" (`anthropic`) provider. Both can be active simultaneously.
 
 = Why add multiple accounts? =
 


### PR DESCRIPTION
## Summary

Addresses the three actionable suggestions from CodeRabbit's review of PR #6 that were merged unresolved (tracked in issue #18).

### Changes

- **readme.txt:39** — provider id reference updated from `anthropic-max` to `ultimate-ai-connector-anthropic-max`; docs now match the renamed provider registered since v1.1.0.
- **readme.txt:56** — same fix in the FAQ entry ("Can I use this alongside the standard Anthropic provider?").
- **js/connector.jsx:660** — `CONFIG` object now wrapped with `Object.freeze()` so the shared reference passed to all five deferred `registerConnector()` calls is immutable and cannot be accidentally mutated between ticks.

### Verification

```
grep 'ultimate-ai-connector-anthropic-max' readme.txt   # should match lines 39 and 56
grep 'Object.freeze' js/connector.jsx                   # should match CONFIG declaration
```

No behaviour change. No version bump needed (documentation and defensive coding only).

Resolves #18