### PR TITLE
chore: initialize aidevops planning infrastructure

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,0 +1,11 @@
+# ai-provider-for-anthropic-max — Agent Instructions
+
+## Project-Specific Rules
+
+<!-- Add project-specific conventions, patterns, and constraints here. -->
+
+## Security
+
+- Never commit secrets, API keys, or credentials
+- Use environment variables or `~/.config/aidevops/credentials.sh` for sensitive values
+- Review all AI-generated code before merging

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# ai-provider-for-anthropic-max
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Build**: `# TODO: add build command`
+- **Test**: `# TODO: add test command`
+- **Deploy**: `# TODO: add deploy command`
+
+## Project Overview
+
+<!-- Brief description of what this project does and why it exists. -->
+
+## Architecture
+
+<!-- Key architectural decisions, tech stack, directory structure. -->
+
+## Conventions
+
+- Commits: [Conventional Commits](https://www.conventionalcommits.org/)
+- Branches: `feature/`, `bugfix/`, `hotfix/`, `refactor/`, `chore/`
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `.agents/AGENTS.md` | Project-specific agent instructions |
+| `TODO.md` | Task tracking |
+| `CHANGELOG.md` | Version history |
+
+<!-- AI-CONTEXT-END -->

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,24 @@
+# TODO
+
+Project task tracking with time estimates, dependencies, and TOON-enhanced parsing.
+
+## Format
+
+Format: `- [ ] tNNN Description @owner #tag ~estimate risk:level logged:date`
+
+## In Progress
+
+<!-- Tasks currently being worked on -->
+
+## Backlog
+
+<!-- Prioritized list of upcoming tasks -->
+
+## Completed
+
+<!-- Tasks that have been completed -->
+
+---
+
+*Format: `- [ ] Task description @owner #tag ~estimate`*
+*Time tracking: `started:`, `completed:`, `actual:`*

--- a/todo/PLANS.md
+++ b/todo/PLANS.md
@@ -1,0 +1,15 @@
+# Execution Plans
+
+Complex, multi-session work that requires detailed planning.
+
+## Active Plans
+
+<!-- Plans currently in progress -->
+
+## Completed Plans
+
+<!-- Archived completed plans -->
+
+---
+
+*See `.agents/workflows/plans.md` for planning workflow*


### PR DESCRIPTION
## Summary

- Add TODO.md for task tracking
- Add AGENTS.md for AI assistant context
- Add .agents/AGENTS.md for project-specific agent instructions
- Add todo/PLANS.md and todo/tasks/ for execution planning

No existing files were overwritten. Only new scaffolding files added.

---
Batch-initialized by aidevops v3.8.63