### PR TITLE
fix(anthropic): normalise empty-array args to empty object for tool_use.input

### DIFF
--- a/src/Models/AnthropicMaxTextGenerationModel.php
+++ b/src/Models/AnthropicMaxTextGenerationModel.php
@@ -362,7 +362,19 @@ class AnthropicMaxTextGenerationModel extends AbstractApiBasedModel implements T
                 throw new RuntimeException('The function_call typed message part must contain a function call.');
             }
             $input = $functionCall->getArgs();
-            if ($input === null) {
+            /*
+             * Anthropic requires tool_use.input to be a JSON object,
+             * never an array. PHP serializes an empty array `[]` as a
+             * JSON array, not an object, so an empty-args function call
+             * (e.g. a parameterless ability) would emit `"input": []`
+             * and trigger a 400:
+             *   `messages.N.content.M.tool_use.input: Input should be
+             *    an object`.
+             *
+             * Normalise both `null` and any empty array to an empty
+             * `stdClass` so json_encode produces `"input": {}`.
+             */
+            if ($input === null || (is_array($input) && count($input) === 0)) {
                 $input = new \stdClass();
             }
             return [


### PR DESCRIPTION
## Problem

When an AI model invokes a tool/ability that takes no arguments, the generated `tool_use` block in the assistant message has `args` stored as an empty PHP array `[]`. When that history is later replayed back to Anthropic's API, PHP's `json_encode([])` serialises it as the JSON array `"[]"`, but Anthropic requires `tool_use.input` to be a JSON object (`"{}"`).

The result is a hard 400 from `https://api.anthropic.com/v1/messages`:

```
Bad Request (400)
messages.$i.content.$j.tool_use.input: Input should be an object
```

Reproducible by:

1. Defining (or using) an ability with no required parameters.
2. Letting the model call it once — the assistant turn is stored with `tool_use.input = []`.
3. Continuing the conversation so that the prior assistant turn is re-sent to Anthropic.

## Fix

Extend the existing `null` normalisation in `formatPart()` to also catch empty PHP arrays before they reach `json_encode`. This mirrors what the SDK already does at the OpenAI-compatible serialization layer (`AbstractOpenAiCompatibleTextGenerationModel::formatPart` ~line 299).

```diff
-            // Ensure null becomes empty object for Anthropic's API which expects an object.
+            // Ensure null or empty array becomes empty object for Anthropic's API which expects an object.
+            // PHP json_encode([]) produces "[]" (array), but Anthropic requires "{}" (object) for tool_use.input.
             $input = $functionCall->getArgs();
-            if ($input === null) {
+            if ($input === null || (is_array($input) && count($input) === 0)) {
                 $input = new \stdClass();
             }
```

Non-empty arrays serialise to objects already (PHP encodes associative arrays as objects), so this only changes behaviour for the previously broken `[]` case.

## Verification

- `php -l src/Models/Anthropic*TextGenerationModel.php` — no syntax errors.
- Manual: round-trip a parameterless tool call through a multi-turn conversation; previously failed with HTTP 400 immediately on the second turn, now succeeds.

## Files

- `src/Models/AnthropicTextGenerationModel.php` (this repo) / `src/Models/AnthropicMaxTextGenerationModel.php` (sibling fork)

Same fix is being submitted to the sibling `Ultimate-Multisite/ai-provider-for-anthropic-max` repo, where the identical bug exists in the renamed `AnthropicMaxTextGenerationModel`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.60 plugin for [OpenCode](https://opencode.ai) v1.15.4 with claude-sonnet-4-6 spent 3d 9h and 383 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of AI function calls with no arguments to ensure proper JSON serialization format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ai-provider-for-anthropic-max/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->