### PR TITLE
fix(anthropic): round-trip thinking signature for extended-thinking + tool-use

### DIFF
--- a/src/Models/AnthropicMaxTextGenerationModel.php
+++ b/src/Models/AnthropicMaxTextGenerationModel.php
@@ -341,15 +341,31 @@ class AnthropicMaxTextGenerationModel extends AbstractApiBasedModel implements T
 
         if ($type->isText()) {
             if ($part->getChannel()->isThought()) {
+                $signature = method_exists($part, 'getThoughtSignature')
+                    ? $part->getThoughtSignature()
+                    : null;
+
+                if (is_string($signature) && '' !== $signature && '{' === $signature[0]) {
+                    $decoded = json_decode($signature, true);
+                    if (
+                        is_array($decoded)
+                        && isset($decoded['type'], $decoded['data'])
+                        && 'redacted_thinking' === $decoded['type']
+                        && is_string($decoded['data'])
+                    ) {
+                        return [
+                            'type' => 'redacted_thinking',
+                            'data' => $decoded['data'],
+                        ];
+                    }
+                }
+
                 $data = [
                     'type'     => 'thinking',
                     'thinking' => $part->getText(),
                 ];
-                if (method_exists($part, 'getThoughtSignature')) {
-                    $signature = $part->getThoughtSignature();
-                    if (null !== $signature) {
-                        $data['signature'] = $signature;
-                    }
+                if (null !== $signature) {
+                    $data['signature'] = $signature;
                 }
                 return $data;
             }
@@ -750,6 +766,23 @@ class AnthropicMaxTextGenerationModel extends AbstractApiBasedModel implements T
                 );
 
             case 'redacted_thinking':
+                if (
+                    !isset($partData['data'])
+                    || !is_string($partData['data'])
+                    || !method_exists(MessagePart::class, 'getThoughtSignature')
+                ) {
+                    return null;
+                }
+                $redactedPayload = wp_json_encode([
+                    'type' => 'redacted_thinking',
+                    'data' => $partData['data'],
+                ]);
+                if (!is_string($redactedPayload)) {
+                    return null;
+                }
+                /** @phpstan-ignore-next-line arguments.count (gated by method_exists check above) */
+                return new MessagePart('', MessagePartChannelEnum::thought(), $redactedPayload);
+
             case 'server_tool_use':
             case 'web_search_tool_result':
                 return null;

--- a/src/Models/AnthropicMaxTextGenerationModel.php
+++ b/src/Models/AnthropicMaxTextGenerationModel.php
@@ -341,10 +341,17 @@ class AnthropicMaxTextGenerationModel extends AbstractApiBasedModel implements T
 
         if ($type->isText()) {
             if ($part->getChannel()->isThought()) {
-                return [
+                $data = [
                     'type'     => 'thinking',
                     'thinking' => $part->getText(),
                 ];
+                if (method_exists($part, 'getThoughtSignature')) {
+                    $signature = $part->getThoughtSignature();
+                    if (null !== $signature) {
+                        $data['signature'] = $signature;
+                    }
+                }
+                return $data;
             }
             return [
                 'type' => 'text',
@@ -716,6 +723,13 @@ class AnthropicMaxTextGenerationModel extends AbstractApiBasedModel implements T
             case 'thinking':
                 if (!isset($partData['thinking']) || !is_string($partData['thinking'])) {
                     throw new InvalidArgumentException('Part has an invalid thinking shape.');
+                }
+                $signature = isset($partData['signature']) && is_string($partData['signature'])
+                    ? $partData['signature']
+                    : null;
+                if (null !== $signature && method_exists(MessagePart::class, 'getThoughtSignature')) {
+                    /** @phpstan-ignore-next-line arguments.count (gated by method_exists check above) */
+                    return new MessagePart($partData['thinking'], MessagePartChannelEnum::thought(), $signature);
                 }
                 return new MessagePart($partData['thinking'], MessagePartChannelEnum::thought());
 


### PR DESCRIPTION
## Summary

Anthropic's Messages API rejects any multi-turn request that echoes back a prior `thinking` content block without its original `signature` — required when extended thinking is enabled and interleaved with `tool_use` blocks. It also rejects requests where `redacted_thinking` blocks are missing on replay. Previously, this plugin's Anthropic model dropped both the signature on `thinking` and `redacted_thinking` blocks entirely, so the second turn of any extended-thinking + tool-use exchange failed with:

```
400 invalid_request_error: messages.N.content.0.thinking.signature: Field required
```

(or, with redacted blocks, a similar shape-mismatch error). This bug only fires when (a) extended thinking is enabled, (b) the model emits at least one tool call OR Anthropic redacts a thinking block, and (c) the agent loop replays the prior assistant message — the path most agents (including superdav-ai-agent) take.

## What changed

`src/Models/AnthropicMaxTextGenerationModel.php` (+48 / −1) across two commits:

### Commit 1 — `thinking` signature

1. **Inbound** (`parseResponseContentMessagePart`, `thinking` case): when the SDK exposes thought signatures, capture `signature` from the response block and pass it as the third `MessagePart` constructor argument.
2. **Outbound** (`getMessagePartData`, thought-channel branch): when the part carries a thought signature, emit it back as `signature` on the outbound `thinking` block.

### Commit 2 — `redacted_thinking`

1. **Inbound** (`parseResponseContentMessagePart`, `redacted_thinking` case): split out of the silent-drop cluster. Pack `{type:'redacted_thinking', data:<encrypted>}` as JSON into the thought-signature slot on an empty-text thought-channel `MessagePart`. Mirrors the JSON-blob signature pattern already used by this plugin's `ChatGptCodexTextGenerationModel::parseReasoningOutputToPart` for OpenAI Responses-API reasoning items.
2. **Outbound** (`getMessagePartData`, thought-channel branch): peek the signature; if it JSON-decodes to `{type:'redacted_thinking', data:<...>}`, emit a `redacted_thinking` block instead of a `thinking` block. Otherwise the existing `thinking` + signature path runs unchanged.

All four edges gated via `method_exists(MessagePart::class, 'getThoughtSignature')` / `method_exists($part, 'getThoughtSignature')` so pre-1.3 SDKs continue to behave exactly as before (no signature field, no constructor third arg, `redacted_thinking` remains a silent drop — same as today).

## Why `method_exists` (not `version_compare`)

The companion upstream PR on `WordPress/ai-provider-for-anthropic` ([#20](https://github.com/WordPress/ai-provider-for-anthropic/pull/20)) uses `version_compare(AiClient::VERSION, '1.3.0', '>=')`. This plugin's existing `ChatGptCodexTextGenerationModel` already uses `method_exists` (e.g. `src/Models/ChatGptCodexTextGenerationModel.php:835`), so the new code matches that local style and is runtime-safe regardless of which SDK package name resolves first.

## Test plan

- [x] Round-trip smoke test through the live WP runtime (reflection on protected `parseResponseContentMessagePart` and `getMessagePartData`):
  - `thinking + signature` block: inbound captures signature, outbound emits identical block — byte-for-byte round-trip.
  - `redacted_thinking` block with arbitrary `data` blob: inbound packs into JSON signature, outbound detects + emits identical block — byte-for-byte round-trip.
  - `thinking` block **without** signature (pre-1.3 SDK fallback shape): inbound returns 2-arg MessagePart, outbound emits no `signature` field — legacy path unchanged.
- [x] Static analysis: `vendor/bin/phpstan analyse src/Models/AnthropicMaxTextGenerationModel.php` — patch adds a few new `class.notFound` warnings, identical in flavour to the 133 pre-existing baseline warnings (SDK is WP-core-provided, not a composer dep). No new real defects.
- [x] Syntax: `php -l src/Models/AnthropicMaxTextGenerationModel.php` — no errors.
- [ ] Live verification with a Max OAuth account against the real Anthropic endpoint — deferred to the merger/maintainer since it requires production Max credentials and an extended-thinking-capable model (Claude Sonnet 4 / Opus 4 with `thinking.type=enabled`) plus at least one tool call in the first turn.

## Companion work

- Upstream Anthropic plugin: [`WordPress/ai-provider-for-anthropic#20`](https://github.com/WordPress/ai-provider-for-anthropic/pull/20) — `feat: Thought signature support` (open, mergeable). Handles `thinking` signature only; this PR's commit 2 (`redacted_thinking`) is a strict superset.
- Upstream OpenAI plugin: [`WordPress/ai-provider-for-openai#26`](https://github.com/WordPress/ai-provider-for-openai/pull/26) — `fix: preserve reasoning round-trip` (open, mergeable). The OpenAI fix is structurally larger because the Responses API encodes reasoning as a top-level output item (with `id` + `encrypted_content` + `summary`) rather than a single signature string, requiring a JSON-blob pack into the SDK's single-string `thoughtSignature` slot — the same pattern this PR's commit 2 reuses for `redacted_thinking`.
