### PR TITLE
feat(codex): expose Spark model

### DIFF
--- a/src/Metadata/ChatGptCodexModelMetadataDirectory.php
+++ b/src/Metadata/ChatGptCodexModelMetadataDirectory.php
@@ -37,18 +37,24 @@ class ChatGptCodexModelMetadataDirectory extends AbstractApiBasedModelMetadataDi
      * with a real ChatGPT Plus/Pro/Team OAuth token. The full set of
      * model ids the upstream opencode CLI references is
      * `gpt-5.5, gpt-5.2, gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5.4,
-     * gpt-5.4-mini`, but the OAuth path rejects the `gpt-5.3-*` and
-     * `gpt-5-codex` ids as "not supported when using Codex with a
-     * ChatGPT account". Only the four below are exposed here; if
-     * future Codex deployments unlock more ids, add them via the
-     * `anthropic_max_chatgpt_codex_models` filter.
+     * gpt-5.4-mini`, but the OAuth path rejects `gpt-5.3-codex`,
+     * `gpt-5.4-codex`, and `gpt-5-codex` as "not supported when using
+     * Codex with a ChatGPT account". Only the working ids below are exposed;
+     * if future Codex deployments unlock more ids, add them via the
+     * `anthropic_max_chatgpt_codex_models` filter. GPT-5.5 is listed first so
+     * SDK consumers that default to the first advertised model prefer it when
+     * the site has not saved an explicit model choice.
      *
      * @var array<int, array{id: string, name: string}>
      */
     private const MODELS = [
-        ['id' => 'gpt-5.4-mini', 'name' => 'GPT-5.4 mini (Codex)'],
-        ['id' => 'gpt-5.4',      'name' => 'GPT-5.4 (Codex)'],
         ['id' => 'gpt-5.5',      'name' => 'GPT-5.5 (Codex)'],
+        ['id' => 'gpt-5.4',      'name' => 'GPT-5.4 (Codex)'],
+        ['id' => 'gpt-5.4-mini', 'name' => 'GPT-5.4 mini (Codex)'],
+        [
+            'id'   => 'gpt-5.3-codex-spark',
+            'name' => 'GPT-5.3 Codex Spark (Codex)',
+        ],
         ['id' => 'gpt-5.2',      'name' => 'GPT-5.2 (Codex)'],
     ];
 

--- a/src/Metadata/ChatGptCodexModelMetadataDirectory.php
+++ b/src/Metadata/ChatGptCodexModelMetadataDirectory.php
@@ -36,14 +36,15 @@ class ChatGptCodexModelMetadataDirectory extends AbstractApiBasedModelMetadataDi
      * Tested against `https://chatgpt.com/backend-api/codex/responses`
      * with a real ChatGPT Plus/Pro/Team OAuth token. The full set of
      * model ids the upstream opencode CLI references is
-     * `gpt-5.5, gpt-5.2, gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5.4,
-     * gpt-5.4-mini`, but the OAuth path rejects `gpt-5.3-codex`,
-     * `gpt-5.4-codex`, and `gpt-5-codex` as "not supported when using
-     * Codex with a ChatGPT account". Only the working ids below are exposed;
-     * if future Codex deployments unlock more ids, add them via the
-     * `anthropic_max_chatgpt_codex_models` filter. GPT-5.5 is listed first so
-     * SDK consumers that default to the first advertised model prefer it when
-     * the site has not saved an explicit model choice.
+     * `gpt-5.5, gpt-5.5-fast, gpt-5.5-pro, gpt-5.4, gpt-5.4-fast,
+     * gpt-5.4-mini, gpt-5.4-mini-fast, gpt-5.3-codex,
+     * gpt-5.3-codex-spark, gpt-5.2`, but the OAuth path rejects the
+     * `*-fast`, `*-pro`, `gpt-5.3-codex`, and `gpt-5.2` ids as "not
+     * supported when using Codex with a ChatGPT account". Only the working
+     * ids below are exposed; if future Codex deployments unlock more ids, add
+     * them via the `anthropic_max_chatgpt_codex_models` filter. GPT-5.5 is
+     * listed first so SDK consumers that default to the first advertised model
+     * prefer it when the site has not saved an explicit model choice.
      *
      * @var array<int, array{id: string, name: string}>
      */
@@ -55,7 +56,6 @@ class ChatGptCodexModelMetadataDirectory extends AbstractApiBasedModelMetadataDi
             'id'   => 'gpt-5.3-codex-spark',
             'name' => 'GPT-5.3 Codex Spark (Codex)',
         ],
-        ['id' => 'gpt-5.2',      'name' => 'GPT-5.2 (Codex)'],
     ];
 
     /**


### PR DESCRIPTION
## Summary

- Exposes `gpt-5.3-codex-spark` in the ChatGPT Codex model metadata directory.
- Keeps `gpt-5.5` first so first-model fallback/default consumers continue to prefer GPT-5.5 when no explicit model is saved.
- Documents the live probe result and limits the exposed list to models that completed through the ChatGPT Codex OAuth backend.

## Investigation

Probed `https://chatgpt.com/backend-api/codex/responses` through the existing OpenAI ChatGPT/Codex OAuth pool without printing token material:

- `gpt-5.5`: HTTP 200, `response.completed`
- `gpt-5.4`: HTTP 200, `response.completed`
- `gpt-5.4-mini`: HTTP 200, `response.completed`
- `gpt-5.3-codex-spark`: HTTP 200, `response.completed`
- `gpt-5.5-fast`: HTTP 400, unsupported with ChatGPT account
- `gpt-5.5-pro`: HTTP 400, unsupported with ChatGPT account
- `gpt-5.4-fast`: HTTP 400, unsupported with ChatGPT account
- `gpt-5.4-mini-fast`: HTTP 400, unsupported with ChatGPT account
- `gpt-5.3-codex`: HTTP 400, unsupported with ChatGPT account
- `gpt-5.4-codex`: HTTP 400, unsupported with ChatGPT account
- `gpt-5-codex`: HTTP 400, unsupported with ChatGPT account
- `gpt-5.2`: HTTP 400, unsupported with ChatGPT account

## Verification

- `php -l src/Metadata/ChatGptCodexModelMetadataDirectory.php`
- `composer validate --no-check-publish`
- Static assertion: `Codex model ids: gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.3-codex-spark`
- `git diff --check`

Notes:
- `vendor/bin/phpcs src/Metadata/ChatGptCodexModelMetadataDirectory.php` currently reports pre-existing/default-standard docblock and line-length findings because the repo has no PHPCS project standard configured.
- `vendor/bin/phpstan analyse src/Metadata/ChatGptCodexModelMetadataDirectory.php` is blocked by existing `phpstan.neon.dist` exclude paths for missing `tests` and `node_modules` directories.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.11 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5
